### PR TITLE
Fix weekly aggregate bug for most recent week

### DIFF
--- a/app/models/turnstile_observation.rb
+++ b/app/models/turnstile_observation.rb
@@ -98,7 +98,7 @@ class TurnstileObservation < ApplicationRecord
     subway.
       where.not(net_entries: nil).
       select("
-        date_trunc('week', observed_at)::date AS week,
+        date_trunc('week', observed_at + '2 days'::interval)::date - '2 days'::interval AS week,
         sum(net_entries) AS entries
       ").
       group(:week).


### PR DESCRIPTION
There was a bug that the weekly aggregate was using Postgres's default week of Monday–Sunday, which is a bug for the most recent week, when it would undercount entries

Each MTA file includes one week of data, Saturday–Friday, so change the weekly aggregate so that each week is a Saturday through a Friday